### PR TITLE
Fix asset paths: use relative base for GitHub Pages compatibility

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -7,8 +7,8 @@
     <meta name="theme-color" content="#0a0a0a" />
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='40' fill='none' stroke='%2300ff9d' stroke-width='6'/><circle cx='50' cy='50' r='15' fill='%2300ff9d'/></svg>" />
     <title>ESW — Ecosystem Services World</title>
-    <script type="module" crossorigin src="/assets/index-DGoAadq1.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BIw036mM.css">
+    <script type="module" crossorigin src="./assets/index-DGoAadq1.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-BIw036mM.css">
   </head>
   <body class="bg-[#0a0a0a] text-white">
     <div id="root"></div>

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,5 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  base: './',
 })


### PR DESCRIPTION
Changed Vite base from '/' to './' so assets resolve correctly regardless of whether the site is served from a custom domain root or a GitHub Pages subdirectory path.

https://claude.ai/code/session_01RZUqyJbX4ecU1nDN8fqQLb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build config/output path change only; low risk aside from potential asset resolution differences when served from the domain root vs a subdirectory.
> 
> **Overview**
> Updates the Vite build `base` to `./` so generated asset URLs are **relative** instead of root-absolute.
> 
> This changes `dist/index.html` to load the bundled JS/CSS from `./assets/...`, improving compatibility when serving the site from a subpath (e.g., GitHub Pages).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d26bb222b2b1d8f3b4b79f82151fb1b9c3219e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->