### PR TITLE
Add Intel section: sector intelligence blog with 8 verified articles

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -41,6 +41,7 @@ Read agents/eco-scientist.md, then apply that role to analyze [site data].
 | `workflows/new-project.md` | Full project intake and phase execution |
 | `workflows/board-meeting.md` | Cross-agent simulation for a given project |
 | `workflows/lead-generation.md` | Target identification and outreach |
+| `workflows/intel-update.md` | Quarterly sector intelligence for website |
 
 ## Design Principles
 

--- a/agents/workflows/intel-update.md
+++ b/agents/workflows/intel-update.md
@@ -1,0 +1,101 @@
+# Workflow: Intel Content Update
+
+> Triggered quarterly or when a major sector development occurs.
+
+## Purpose
+
+Research, draft, and publish sector intelligence articles for the ESW website's "Intel" section. This workflow ensures the Intel feed stays current with verified, citation-backed developments across ecosystem services, regulatory frameworks, carbon/biodiversity markets, and sustainable finance.
+
+## Trigger
+
+- Quarterly scheduled cycle (January, April, July, October)
+- Major regulatory announcement (CSRD update, TNFD milestone, new crediting methodology)
+- COP or major international summit outcomes
+- Significant market event (new credit framework, landmark green bond issuance)
+
+## Sequence
+
+```
+Phase 1: RESEARCH
+  → Brand Voice identifies topics requiring coverage
+  → Brand Voice researches developments across these domains:
+    1. EU regulation (CSRD, EU Taxonomy, ESRS, Nature Restoration Law, EUDR)
+    2. Disclosure frameworks (TNFD, ISSB, IFRS S1/S2)
+    3. Biodiversity credits (Verra Nature Framework, BNG, national schemes)
+    4. Carbon markets (VCS, Gold Standard, Article 6, ICVCM)
+    5. Nature-based Solutions policy (national NbS policies, UNEP)
+    6. CBD/COP outcomes (Kunming-Montreal GBF progress)
+    7. Green/sustainability-linked bonds (EuGB, ICMA, market data)
+  → GATE: Research verified with primary sources
+
+Phase 2: DRAFTING
+  → Brand Voice drafts articles in the Intel format (below)
+  → Each article must include: date, category, title, summary, tags
+  → Eco-Scientist reviews for ecological/scientific accuracy
+  → Legal Compliance reviews for regulatory accuracy
+  → Green Financier reviews for financial/market accuracy
+  → GATE: All reviewers confirm accuracy
+
+Phase 3: PUBLICATION
+  → Brand Voice delivers final article data to be added to
+    src/components/Intel.jsx
+  → New articles are prepended to the articles array (newest first)
+  → Old articles (>18 months) are archived or removed
+  → GATE: Build passes, content reviewed on staging
+```
+
+## Article Format
+
+Each article in Intel.jsx follows this structure:
+
+```javascript
+{
+  date: 'Month YYYY',           // e.g., 'January 2026'
+  category: 'Category Name',    // One of the defined categories
+  title: 'Headline (max 80 chars)',
+  summary: 'Body text (2-3 sentences, max 280 chars). Factual, dense, citation-worthy.',
+  tags: ['Tag1', 'Tag2', 'Tag3'],  // 2-4 tags, uppercase abbreviations preferred
+  highlight: false,              // Set true for major developments only
+}
+```
+
+## Categories
+
+| Category | Covers |
+|---|---|
+| EU Regulation | CSRD, ESRS, EU Taxonomy, EUDR, Nature Restoration Law |
+| Disclosure | TNFD, ISSB, IFRS, corporate reporting standards |
+| Biodiversity Credits | Verra Nature Framework, BNG, national credit schemes |
+| Carbon Markets | VCS, Gold Standard, Article 6, ICVCM, CORSIA |
+| NbS Policy | Nature-based Solutions legislation, UNEP, national policies |
+| COP16 / COP17 | CBD summit outcomes and follow-up |
+| Green Bonds | EuGB, ICMA, SLBs, market data |
+
+## Content Standards
+
+1. **Verified facts only.** Every claim must be traceable to a primary source (regulation text, official announcement, credible publication). No speculation.
+2. **Date-specific.** Include the exact month and year. If a specific date is known (e.g., "26 February 2025"), include it in the summary.
+3. **Dense.** Summaries are 2-3 sentences maximum. No filler, no editorializing. State what happened and why it matters.
+4. **Framework references.** Always name the specific regulation, standard, or methodology (e.g., "VM0047 v1.1", not "a new methodology").
+5. **ESW relevance.** Every article must be relevant to ESW's service offerings. If it doesn't affect ecological assessment, NbS design, credit structuring, or disclosure advisory, it doesn't belong in Intel.
+6. **No comparisons to other firms.** Intel is about the sector, not competitors.
+
+## Review Checklist
+
+| Check | Reviewer |
+|---|---|
+| Ecological/scientific claims are accurate | Eco-Scientist |
+| Regulatory citations are correct and current | Legal Compliance |
+| Financial/market data is accurate | Green Financier |
+| Tone is institutional, not promotional | Brand Voice |
+| Tags match the defined taxonomy | Brand Voice |
+| No stale articles (>18 months old) remain | Brand Voice |
+
+## Quarterly Calendar
+
+| Quarter | Coverage Focus |
+|---|---|
+| Q1 (January) | Year-in-review, regulatory outlook, market forecasts |
+| Q2 (April) | EU legislative cycle updates, spring summit outcomes |
+| Q3 (July) | Mid-year market data, methodology updates |
+| Q4 (October) | COP preparation/outcomes, year-end regulation deadlines |

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Services from './components/Services'
 import Approach from './components/Approach'
 import Finance from './components/Finance'
 import CaseStudies from './components/CaseStudies'
+import Intel from './components/Intel'
 import Contact from './components/Contact'
 import PrivacyPolicy from './components/PrivacyPolicy'
 import Footer from './components/Footer'
@@ -29,6 +30,7 @@ function App() {
       <Approach />
       <Finance />
       <CaseStudies />
+      <Intel />
       <Contact />
       <PrivacyPolicy />
       <Footer />

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -17,6 +17,7 @@ function Footer() {
             <a href="#about" className="hover:text-accent transition-colors">About</a>
             <a href="#services" className="hover:text-accent transition-colors">Services</a>
             <a href="#approach" className="hover:text-accent transition-colors">Approach</a>
+            <a href="#intel" className="hover:text-accent transition-colors">Intel</a>
             <a href="#contact" className="hover:text-accent transition-colors">Contact</a>
             <a href="#privacy" className="hover:text-accent transition-colors">Privacy</a>
           </div>

--- a/src/components/Intel.jsx
+++ b/src/components/Intel.jsx
@@ -1,0 +1,163 @@
+import React, { useState } from 'react'
+import useReveal from '../hooks/useReveal'
+
+const articles = [
+  {
+    date: 'January 2026',
+    category: 'Biodiversity Credits',
+    title: 'Verra Opens Nature Framework to All Projects',
+    summary:
+      'Verra has opened its Nature Framework certification process to all projects globally, enabling quantification of biodiversity outcomes and generation of Nature Credits under the SD VISta standard. First validation/verification bodies approved throughout 2025.',
+    tags: ['Verra', 'Nature Credits', 'SD VISta'],
+    highlight: true,
+  },
+  {
+    date: 'December 2025',
+    category: 'EU Regulation',
+    title: 'CSRD Omnibus: Scope Reduced by 85%, Thresholds Raised',
+    summary:
+      'Council and Parliament reached provisional agreement on the Omnibus Simplification Package. CSRD scope now requires both >1,000 employees and >EUR 450M turnover. Mandatory ESRS data points reduced by 61%. Applies from FY 2027.',
+    tags: ['CSRD', 'ESRS', 'EU Taxonomy'],
+  },
+  {
+    date: 'November 2025',
+    category: 'Carbon Markets',
+    title: 'Article 6.2 Crediting Protocol Published at COP30',
+    summary:
+      'Singapore, Gold Standard, and Verra published the final Article 6.2 Crediting Protocol at COP30 in Belem, enabling governments to use independent crediting programs for national climate goals under the Paris Agreement.',
+    tags: ['Article 6', 'COP30', 'Paris Agreement'],
+  },
+  {
+    date: 'November 2025',
+    category: 'Disclosure',
+    title: 'ISSB to Develop Nature Disclosure Standard, Drawing on TNFD',
+    summary:
+      'The ISSB announced it will advance nature-related disclosure requirements, drawing on the TNFD framework. TNFD signed a MoU with the IFRS Foundation and will complete technical work by Q3 2026. Exposure Draft targeted for COP17 in October 2026.',
+    tags: ['TNFD', 'ISSB', 'IFRS'],
+  },
+  {
+    date: 'July 2025',
+    category: 'EU Policy',
+    title: 'European Commission Launches Roadmap towards Nature Credits',
+    summary:
+      'The EC launched its formal Roadmap for a nature credit system across the EU. Expert group established in 2025, certification framework principles due 2027. Nature credits defined as quantifiable, fungible units for verified biodiversity outcomes.',
+    tags: ['EU', 'Nature Credits', 'Biodiversity'],
+    highlight: true,
+  },
+  {
+    date: 'February 2025',
+    category: 'COP16',
+    title: 'COP16 Rome: $200 Billion/Year Biodiversity Finance Target Agreed',
+    summary:
+      'The resumed COP16 session in Rome completed all remaining agenda items, agreeing on a resource mobilization strategy of at least $200 billion/year by 2030. The Cali Fund for DSI benefit-sharing was officially launched by UNDP and UNEP.',
+    tags: ['COP16', 'CBD', 'Biodiversity Finance'],
+  },
+  {
+    date: 'January 2025',
+    category: 'Green Bonds',
+    title: 'First Corporate European Green Bond Issued Under New EuGB Standard',
+    summary:
+      'A2A S.p.A. issued the first-ever corporate EuGB (EUR 500M, 4.4x oversubscribed), followed by EIB\'s EUR 3 billion issuance at 13x oversubscription. Over EUR 22 billion issued under the standard in its first year.',
+    tags: ['EuGB', 'Green Bonds', 'EU Taxonomy'],
+  },
+  {
+    date: '2025',
+    category: 'NbS Policy',
+    title: 'EU Nature Restoration Law Enters Implementation Phase',
+    summary:
+      'Member States must prepare National Restoration Plans by September 2026. Targets: restoration measures on at least 20% of EU land and sea areas by 2030, with 30% of habitats in poor condition restored. Commission adopted a uniform format for plans in May 2025.',
+    tags: ['EU NRL', 'Restoration', 'NbS'],
+  },
+]
+
+const categories = ['All', ...new Set(articles.map((a) => a.category))]
+
+function Intel() {
+  const [ref, visible] = useReveal()
+  const [activeCategory, setActiveCategory] = useState('All')
+
+  const filtered =
+    activeCategory === 'All'
+      ? articles
+      : articles.filter((a) => a.category === activeCategory)
+
+  return (
+    <section id="intel" className="py-24 md:py-32 bg-white/[0.01]">
+      <div
+        ref={ref}
+        className={`max-w-7xl mx-auto px-6 transition-all duration-700 ${
+          visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
+        }`}
+      >
+        <div className="max-w-2xl mb-12">
+          <span className="text-accent text-sm tracking-wider uppercase">Intel</span>
+          <h2 className="text-3xl md:text-4xl font-bold mt-3 mb-4">
+            Sector intelligence
+          </h2>
+          <p className="text-gray-400">
+            Regulatory developments, market movements, and policy shifts shaping the
+            ecosystem services landscape. Curated by ESW&apos;s research team.
+          </p>
+        </div>
+
+        {/* Category filter */}
+        <div className="flex flex-wrap gap-2 mb-10">
+          {categories.map((cat) => (
+            <button
+              key={cat}
+              onClick={() => setActiveCategory(cat)}
+              className={`text-xs tracking-wider uppercase px-4 py-2 rounded-full border transition-all duration-200 ${
+                activeCategory === cat
+                  ? 'border-accent text-accent bg-accent/10'
+                  : 'border-white/10 text-gray-500 hover:border-white/20 hover:text-gray-300'
+              }`}
+            >
+              {cat}
+            </button>
+          ))}
+        </div>
+
+        {/* Articles grid */}
+        <div className="grid md:grid-cols-2 gap-6">
+          {filtered.map((article) => (
+            <article
+              key={article.title}
+              className={`group p-8 rounded-lg border bg-white/[0.02] hover:border-accent/30 transition-all duration-300 flex flex-col ${
+                article.highlight ? 'border-accent/20' : 'border-white/5'
+              }`}
+            >
+              <div className="flex items-center gap-3 mb-4">
+                <span className="text-xs tracking-wider uppercase text-accent">
+                  {article.category}
+                </span>
+                <span className="text-gray-700">|</span>
+                <span className="text-xs text-gray-600">{article.date}</span>
+              </div>
+
+              <h3 className="text-lg font-semibold mb-3 group-hover:text-accent transition-colors duration-300 leading-snug">
+                {article.title}
+              </h3>
+
+              <p className="text-sm text-gray-400 leading-relaxed mb-6 flex-1">
+                {article.summary}
+              </p>
+
+              <div className="flex flex-wrap gap-2">
+                {article.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="text-[10px] tracking-wider uppercase px-2 py-1 rounded border border-white/10 text-gray-500"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default Intel

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -5,6 +5,7 @@ const navLinks = [
   { label: 'Services', href: '#services' },
   { label: 'Approach', href: '#approach' },
   { label: 'Finance', href: '#finance' },
+  { label: 'Intel', href: '#intel' },
   { label: 'Contact', href: '#contact' },
 ]
 


### PR DESCRIPTION
- New Intel component with category filtering (EU Regulation, Disclosure, Biodiversity Credits, Carbon Markets, NbS Policy, COP16, Green Bonds)
- 8 articles covering 2025-2026 developments: CSRD Omnibus, Article 6.2 Protocol, TNFD-ISSB convergence, Verra Nature Framework, EU Nature Credits Roadmap, COP16 Rome outcomes, EuGB standard, Nature Restoration Law
- Added Intel to Navbar, Footer, and App layout
- Created intel-update.md agent workflow for quarterly content generation
- All content verified against primary sources

https://claude.ai/code/session_01RZUqyJbX4ecU1nDN8fqQLb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/content change that adds a new section and navigation anchors without touching auth, data storage, or backend logic.
> 
> **Overview**
> Adds a new `Intel` section to the landing page, rendering a curated set of sector-intelligence articles with simple client-side category filtering and highlighted items.
> 
> Wires the section into the main page flow (`App.jsx`) and adds `#intel` navigation links in both `Navbar` and `Footer`.
> 
> Documents a new quarterly content maintenance workflow in `agents/workflows/intel-update.md` and registers it in `agents/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e3504178d90d61a3954c735ad7aa9d194c41d2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->