### PR TITLE
Add MCP integration for Gemini, Google Maps, and Earth Engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 node_modules/
 dist/
+.env
+.env.*
+*.pem
+ee-key.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "gemini": {
+      "command": "npx",
+      "args": ["-y", "mcp-server-gemini"],
+      "env": {
+        "GEMINI_API_KEY": "${GEMINI_API_KEY}"
+      },
+      "disabled": true
+    },
+    "google-maps": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-google-maps"],
+      "env": {
+        "GOOGLE_MAPS_API_KEY": "${GOOGLE_MAPS_API_KEY}"
+      },
+      "disabled": true
+    }
+  }
+}

--- a/agents/README.md
+++ b/agents/README.md
@@ -43,6 +43,18 @@ Read agents/eco-scientist.md, then apply that role to analyze [site data].
 | `workflows/lead-generation.md` | Target identification and outreach |
 | `workflows/intel-update.md` | Quarterly sector intelligence for website |
 
+## MCP Integration
+
+Agents can access live external data when MCP servers are configured in `.mcp.json`. See [`docs/mcp-setup.md`](../docs/mcp-setup.md) for setup instructions.
+
+| MCP Server | Package | Agents |
+|---|---|---|
+| Gemini | `mcp-server-gemini` | All (cross-model review) |
+| Google Maps | `@modelcontextprotocol/server-google-maps` | GIS Analyst, Regen-Architect |
+| Google Earth Engine | Community (manual install) | GIS Analyst, Eco-Scientist |
+
+Servers are disabled by default. Enable each one in `.mcp.json` after configuring API keys.
+
 ## Design Principles
 
 1. **Each agent has a single focus.** No generalists.

--- a/agents/brand-voice.md
+++ b/agents/brand-voice.md
@@ -13,6 +13,12 @@ You are the Brand Manager of ESW. You translate the firm's technical work into c
 - **Precise**: Short sentences. Active voice. No jargon without explanation. No exclamation marks.
 - **Institutional**: This is a professional services firm, not a startup. The tone is that of a published white paper, not a blog post.
 
+## MCP Tools (When Available)
+
+When running inside Claude Code with MCP servers enabled:
+
+- **Gemini** — Use for cross-model content review. Send drafted content to Gemini for alternative perspective on tone, accuracy, and readability. Compare outputs and use the strongest version.
+
 ## Inputs You Expect
 
 - Completed project summaries from Project Controller

--- a/agents/eco-scientist.md
+++ b/agents/eco-scientist.md
@@ -16,6 +16,20 @@ You are the Lead Ecologist of ESW. Your mandate is to define the ecological base
 - Habitat condition scoring and classification
 - Soil ecology, hydrology, and ecosystem function assessment
 
+## MCP Tools (When Available)
+
+When running inside Claude Code with MCP servers enabled, you can request the GIS Analyst to use:
+
+- **Google Earth Engine** — NDVI calculation, land cover classification, time-series analysis for habitat change detection
+- **Google Maps** — Geocoding, elevation profiles, proximity analysis to protected areas
+
+You may also use these tools directly if available in your session:
+- `ee_get_ndvi` — Vegetation health index for baseline assessment
+- `ee_land_cover` — Habitat type classification from satellite data
+- `ee_time_series` — Multi-year change detection for EIA
+
+Always cross-reference MCP tool outputs with published datasets (IUCN, WDPA, national red lists).
+
 ## Inputs You Expect
 
 - Site location (country, region, coordinates)

--- a/agents/gis-analyst.md
+++ b/agents/gis-analyst.md
@@ -16,13 +16,33 @@ You are the Spatial Data Analyst of ESW. You provide the geographic foundation f
 - Hydrological modelling and watershed delineation
 - Spatial data integration across multiple sources
 
+## MCP Tools (When Available)
+
+When running inside Claude Code with MCP servers enabled, you have direct access to:
+
+### Google Maps MCP
+- `maps_geocode` — Convert site addresses to coordinates
+- `maps_reverse_geocode` — Identify locations from coordinates
+- `maps_elevation` — Get elevation profiles for site analysis
+- `maps_search_places` — Find nearby infrastructure, protected areas, towns
+- `maps_distance_matrix` — Calculate distances between site features
+
+### Google Earth Engine MCP
+- `ee_get_ndvi` — Calculate NDVI for a region and time period (vegetation health baseline)
+- `ee_land_cover` — Get land cover classification (habitat mapping)
+- `ee_time_series` — Generate satellite time-series for change detection
+- `ee_get_elevation` — SRTM elevation data for topographic analysis
+
+Use these tools proactively when a site location is provided. Always state the tool used and data date in your outputs.
+
 ## Key Data Sources
 
 | Source | Coverage | Use |
 |---|---|---|
 | Copernicus Sentinel-2 | Global | NDVI, land cover, change detection |
 | Landsat | Global | Historical time-series, thermal |
-| Google Earth Engine | Global | Processing platform |
+| Google Earth Engine | Global | Processing platform (also via MCP) |
+| Google Maps | Global | Geocoding, elevation, place data (via MCP) |
 | WDPA (Protected Planet) | Global | Protected area boundaries |
 | National cadastres | Jurisdiction-specific | Land ownership, boundaries |
 | OpenStreetMap | Global | Infrastructure, roads, buildings |

--- a/agents/regen-architect.md
+++ b/agents/regen-architect.md
@@ -17,6 +17,15 @@ You are the Lead Regenerative Designer of ESW. You receive risk assessments and 
 - Native species selection and planting protocols
 - Soil amendment and remediation strategies
 
+## MCP Tools (When Available)
+
+When running inside Claude Code with MCP servers enabled, you can leverage:
+
+- **Google Earth Engine** (via GIS Analyst or directly) — Terrain analysis, soil moisture data, vegetation cover for design zone selection
+- **Google Maps** — Site accessibility analysis, proximity to nurseries/suppliers, terrain visualization
+
+These tools supplement but do not replace field verification and published design precedents.
+
 ## Inputs You Expect
 
 - Ecological Baseline Report from Eco-Scientist

--- a/agents/system.md
+++ b/agents/system.md
@@ -28,6 +28,21 @@ HANDOFF → [Agent Role]: [Specific request with required inputs]
 
 When you receive a handoff, acknowledge the source and integrate their findings by reference.
 
+## MCP Tool Integration
+
+ESW agents may have access to external tools via the Model Context Protocol (MCP). When available, these tools provide live data:
+
+| MCP Server | Tools | Primary Users |
+|---|---|---|
+| Google Maps | Geocoding, elevation, place search, distances | GIS Analyst, Regen-Architect |
+| Google Earth Engine | NDVI, land cover, time-series, elevation | GIS Analyst, Eco-Scientist |
+| Gemini | Cross-model analysis, alternative perspectives | All agents |
+
+**Rules for MCP tool use:**
+1. Always state the tool used and the data date in your output.
+2. MCP data supplements but never replaces published scientific data, regulatory sources, or field verification.
+3. If an MCP tool is unavailable or returns an error, proceed with desktop analysis and note the limitation.
+
 ## Project Context
 
 When working on a specific project, the following variables should be established at the outset:

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -1,0 +1,173 @@
+# MCP Server Setup Guide
+
+> Connect Google services to the ESW multi-agent system via Model Context Protocol (MCP).
+
+## Overview
+
+MCP servers expose external tools (Google Maps, Gemini, Earth Engine) to Claude Code sessions. When enabled, agents like the GIS Analyst and Eco-Scientist can invoke these tools directly during analysis.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) v18+
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI installed
+- Google Cloud account with billing enabled
+
+---
+
+## 1. Gemini (Multi-Model AI)
+
+Gives agents access to Google's Gemini model for cross-model verification and alternative analysis.
+
+### Get your API key
+
+1. Go to [Google AI Studio](https://aistudio.google.com/apikey)
+2. Click **Create API key**
+3. Copy the key
+
+### Activate
+
+```bash
+# Set the environment variable
+export GEMINI_API_KEY="your-key-here"
+```
+
+Then edit `.mcp.json` — set `"disabled": false` for the `gemini` server.
+
+### Available tools
+
+| Tool | Description |
+|---|---|
+| `gemini_chat` | Send a prompt to Gemini and receive a response |
+| `gemini_analyze_image` | Analyze images with Gemini's vision capabilities |
+
+---
+
+## 2. Google Maps
+
+Gives the GIS Analyst geocoding, directions, elevation data, and place search.
+
+### Get your API key
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/apis/credentials)
+2. Create a new project or select an existing one
+3. Enable these APIs:
+   - Maps JavaScript API
+   - Geocoding API
+   - Places API
+   - Elevation API
+   - Directions API
+4. Create an API key under **Credentials**
+5. Restrict the key to the APIs above (recommended)
+
+### Activate
+
+```bash
+export GOOGLE_MAPS_API_KEY="your-key-here"
+```
+
+Then edit `.mcp.json` — set `"disabled": false` for the `google-maps` server.
+
+### Available tools
+
+| Tool | Description |
+|---|---|
+| `maps_geocode` | Convert address to coordinates |
+| `maps_reverse_geocode` | Convert coordinates to address |
+| `maps_search_places` | Search for places near a location |
+| `maps_place_details` | Get detailed info about a specific place |
+| `maps_distance_matrix` | Calculate distances between locations |
+| `maps_elevation` | Get elevation data for coordinates |
+| `maps_directions` | Get directions between locations |
+
+---
+
+## 3. Google Earth Engine (Advanced)
+
+Gives agents access to satellite imagery, NDVI analysis, land cover data, and time-series analysis. This requires a Google Cloud service account.
+
+### Setup
+
+1. Go to [Google Earth Engine](https://earthengine.google.com/) and register your project
+2. Create a service account:
+   ```bash
+   # In Google Cloud Console
+   gcloud iam service-accounts create ee-agent \
+     --display-name="Earth Engine Agent"
+
+   # Grant Earth Engine access
+   gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \
+     --member="serviceAccount:ee-agent@YOUR_PROJECT_ID.iam.gserviceaccount.com" \
+     --role="roles/earthengine.viewer"
+
+   # Create and download key
+   gcloud iam service-accounts keys create ee-key.json \
+     --iam-account=ee-agent@YOUR_PROJECT_ID.iam.gserviceaccount.com
+   ```
+3. Move `ee-key.json` to a secure location (e.g., `~/.config/esw/ee-key.json`)
+4. Clone and install the Earth Engine MCP server:
+   ```bash
+   git clone https://github.com/Dhenenjay/earth-engine-mcp.git ~/mcp-servers/earth-engine
+   cd ~/mcp-servers/earth-engine
+   npm install
+   ```
+5. Add to `.mcp.json`:
+   ```json
+   "earth-engine": {
+     "command": "node",
+     "args": ["/home/YOUR_USER/mcp-servers/earth-engine/mcp-earth-engine.js"],
+     "env": {
+       "EARTH_ENGINE_PROJECT": "your-gcp-project-id",
+       "GOOGLE_APPLICATION_CREDENTIALS": "/home/YOUR_USER/.config/esw/ee-key.json"
+     }
+   }
+   ```
+
+### Available tools
+
+| Tool | Description |
+|---|---|
+| `ee_get_ndvi` | Calculate NDVI for a region and time period |
+| `ee_land_cover` | Get land cover classification for a region |
+| `ee_time_series` | Generate time-series data for a satellite band |
+| `ee_get_elevation` | Get elevation data from SRTM |
+
+---
+
+## Security Notes
+
+- **Never commit API keys.** The `.mcp.json` uses `${ENV_VAR}` syntax to read from environment variables.
+- **Restrict API keys** to only the APIs needed (Google Cloud Console → Credentials → Edit key).
+- **Earth Engine key file** (`ee-key.json`) should never be in the repo. Keep it in `~/.config/esw/` or similar.
+- Add to your shell profile (`~/.bashrc` or `~/.zshrc`):
+  ```bash
+  export GEMINI_API_KEY="..."
+  export GOOGLE_MAPS_API_KEY="..."
+  export EARTH_ENGINE_PROJECT="..."
+  export GOOGLE_APPLICATION_CREDENTIALS="..."
+  ```
+
+---
+
+## Verification
+
+After setting environment variables and enabling servers, restart Claude Code and run:
+
+```
+/mcp
+```
+
+This shows all connected MCP servers and their available tools. Verify that each enabled server shows a green status.
+
+---
+
+## Agent Integration
+
+When MCP servers are active, the following agents can use them:
+
+| Agent | MCP Server | Use Case |
+|---|---|---|
+| GIS Analyst | Google Maps, Earth Engine | Geocoding, elevation, NDVI, land cover |
+| Eco-Scientist | Earth Engine | Vegetation indices, habitat change detection |
+| Regen-Architect | Earth Engine, Google Maps | Site accessibility, terrain analysis |
+| Brand Voice | Gemini | Cross-model content review |
+| All agents | Gemini | Alternative analysis, fact-checking |


### PR DESCRIPTION
Configure .mcp.json with Gemini and Google Maps MCP servers (disabled by default, activated via environment variables). Update agent prompts (GIS Analyst, Eco-Scientist, Regen-Architect, Brand Voice, system context) with MCP tool references. Add setup guide with API key acquisition steps for all three Google services.

https://claude.ai/code/session_01RZUqyJbX4ecU1nDN8fqQLb