### PR TITLE
Remove explicit framework setting to fix serverless function detection

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,6 @@
 {
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "framework": "vite",
   "functions": {
     "api/index.js": {
       "maxDuration": 60,


### PR DESCRIPTION
Vercel's explicit "framework": "vite" setting was preventing the api/ directory from being deployed as serverless functions (404 on all API routes). Removing it lets Vercel auto-detect Vite from vite.config.js while properly handling the api/ directory for serverless functions.

https://claude.ai/code/session_01VaNsHFwMg9dP1SrRyciD6D