### PR TITLE
Add local dev server for running API outside Vercel

### DIFF
--- a/api/dev-server.js
+++ b/api/dev-server.js
@@ -1,0 +1,28 @@
+/**
+ * Local development server — wraps the Vercel serverless handler
+ * in an Express app so `npm run api` works outside Vercel.
+ */
+
+import 'dotenv/config'
+import express from 'express'
+import handler from './index.js'
+
+const app = express()
+const PORT = process.env.PORT || 3001
+
+app.use(express.json())
+
+// Adapt Express req/res to match what the handler expects
+app.all('/api/*', (req, res) => handler(req, res))
+app.all('/*', (req, res) => {
+  // Prefix with /api so the handler's path matching works
+  req.url = `/api${req.url}`
+  handler(req, res)
+})
+
+app.listen(PORT, () => {
+  console.log(`ESW API dev server running at http://localhost:${PORT}`)
+  console.log(`  Health:  http://localhost:${PORT}/api/health`)
+  console.log(`  Chat:    POST http://localhost:${PORT}/api/chat`)
+  console.log(`  API key: ${process.env.ANTHROPIC_API_KEY ? 'configured' : 'MISSING — set ANTHROPIC_API_KEY in api/.env'}`)
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@react-three/fiber": "^8.13.6",
         "@vitejs/plugin-react": "^5.1.3",
         "cors": "^2.8.5",
+        "dotenv": "^17.3.1",
         "express": "^4.21.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2189,6 +2190,18 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/draco3d": {
       "version": "1.5.7",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "node scripts/bundle-agents.js && vite build",
     "build:agents": "node scripts/bundle-agents.js",
     "preview": "vite preview",
-    "api": "node api/index.js",
+    "api": "node api/dev-server.js",
     "dev:full": "concurrently \"npm run api\" \"npm run dev\""
   },
   "dependencies": {
@@ -16,6 +16,7 @@
     "@react-three/fiber": "^8.13.6",
     "@vitejs/plugin-react": "^5.1.3",
     "cors": "^2.8.5",
+    "dotenv": "^17.3.1",
     "express": "^4.21.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
Wraps the serverless handler in Express so `npm run api` starts a real HTTP server on localhost:3001. Adds dotenv for loading api/.env locally.

https://claude.ai/code/session_01VaNsHFwMg9dP1SrRyciD6D