### PR TITLE
feat: add web-based Decarbonization Tool with 3-panel UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,10 +12,12 @@ import Contact from './components/Contact'
 import Footer from './components/Footer'
 import ImageBreak from './components/ImageBreak'
 import ESWChat from './components/ESWChat'
+import DecarbonizationTool from './components/decarb/DecarbonizationTool'
 
 function App() {
   const [scrolled, setScrolled] = useState(false)
   const [chatOpen, setChatOpen] = useState(false)
+  const [decarbOpen, setDecarbOpen] = useState(false)
 
   useEffect(() => {
     const handleScroll = () => setScrolled(window.scrollY > 50)
@@ -28,6 +30,16 @@ function App() {
     window.addEventListener('open-esw-ai', handleOpenChat)
     return () => window.removeEventListener('open-esw-ai', handleOpenChat)
   }, [])
+
+  useEffect(() => {
+    const handleOpenDecarb = () => setDecarbOpen(true)
+    window.addEventListener('open-decarb-tool', handleOpenDecarb)
+    return () => window.removeEventListener('open-decarb-tool', handleOpenDecarb)
+  }, [])
+
+  if (decarbOpen) {
+    return <DecarbonizationTool onClose={() => setDecarbOpen(false)} />
+  }
 
   if (chatOpen) {
     return <ESWChat onClose={() => setChatOpen(false)} />

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -71,6 +71,12 @@ function Navbar({ scrolled }) {
               Contact
             </a>
             <button
+              onClick={() => window.dispatchEvent(new CustomEvent('open-decarb-tool'))}
+              className="text-label uppercase px-5 py-2 border border-navy text-navy hover:bg-navy-50 transition-all duration-200"
+            >
+              Decarb Tool
+            </button>
+            <button
               onClick={() => window.dispatchEvent(new CustomEvent('open-esw-ai'))}
               className="text-label uppercase px-5 py-2 bg-navy text-white hover:bg-navy-800 transition-all duration-200"
             >
@@ -116,8 +122,14 @@ function Navbar({ scrolled }) {
             Contact
           </a>
           <button
+            onClick={() => { setMenuOpen(false); window.dispatchEvent(new CustomEvent('open-decarb-tool')) }}
+            className="block w-full mt-4 text-label uppercase text-center px-5 py-3 border border-navy text-navy"
+          >
+            Decarb Tool
+          </button>
+          <button
             onClick={() => { setMenuOpen(false); window.dispatchEvent(new CustomEvent('open-esw-ai')) }}
-            className="block w-full mt-4 text-label uppercase text-center px-5 py-3 bg-navy text-white"
+            className="block w-full mt-2 text-label uppercase text-center px-5 py-3 bg-navy text-white"
           >
             ESW.AI
           </button>

--- a/src/components/decarb/CalculationTable.jsx
+++ b/src/components/decarb/CalculationTable.jsx
@@ -1,0 +1,302 @@
+import React, { useState } from 'react'
+import { toCSV, downloadFile, autoAssignCosts } from '../../lib/decarbEngine'
+
+function ScopeBar({ label, value, total, color }) {
+  const pct = total > 0 ? (value / total) * 100 : 0
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-label uppercase text-slate w-28">{label}</span>
+      <div className="flex-1 h-6 bg-sovereign-ash relative">
+        <div className={`h-full ${color}`} style={{ width: `${Math.min(pct, 100)}%` }} />
+      </div>
+      <span className="font-mono text-sm text-navy w-28 text-right">{value.toLocaleString('es-ES', { maximumFractionDigits: 1 })} t</span>
+      <span className="text-xs text-slate w-12 text-right">{pct.toFixed(1)}%</span>
+    </div>
+  )
+}
+
+export default function CalculationTable({
+  results, summary, diagnostic, measures, setMeasures, onGenerateReport
+}) {
+  const [activeTab, setActiveTab] = useState('inventario')
+
+  const exportInventory = () => {
+    const headers = ['Fuente', 'Scope', 'Categoría', 'Cantidad', 'Unidad', 'Factor', 'GWP', 'tCO2e']
+    const rows = results.map(r => ({
+      'Fuente': r.nombre, 'Scope': r.scope, 'Categoría': r.categoria,
+      'Cantidad': r.cantidad, 'Unidad': r.unidad, 'Factor': r.factor_emision,
+      'GWP': r.gwp, 'tCO2e': r.tCO2e,
+    }))
+    downloadFile(toCSV(headers, rows), 'inventario_emisiones.csv')
+  }
+
+  const exportMeasures = () => {
+    const headers = ['ID', 'Medida', 'Fuente', 'Palanca', 'Horizonte', 'tCO2e/año', 'Vida útil', 'CAPEX (€)', 'Ahorro anual (€)']
+    const rows = measures.map(m => ({
+      'ID': m.id, 'Medida': m.nombre, 'Fuente': m.source_nombre,
+      'Palanca': m.palanca, 'Horizonte': m.horizonte,
+      'tCO2e/año': m.tCO2e_anuales, 'Vida útil': m.vida_util_anios,
+      'CAPEX (€)': m.capex_eur, 'Ahorro anual (€)': m.ahorro_anual_eur,
+    }))
+    downloadFile(toCSV(headers, rows), 'medidas_reduccion.csv')
+  }
+
+  const updateMeasure = (index, field, value) => {
+    const updated = [...measures]
+    updated[index] = { ...updated[index], [field]: value }
+    setMeasures(updated)
+  }
+
+  const applyDefaultCosts = () => {
+    setMeasures(autoAssignCosts(measures))
+  }
+
+  const hasCosts = measures.some(m => m.capex_eur > 0 || m.ahorro_anual_eur > 0)
+
+  const tabs = [
+    { id: 'inventario', label: 'Inventario GEI' },
+    { id: 'diagnostico', label: 'Diagnóstico' },
+    { id: 'medidas', label: 'Medidas de Reducción' },
+  ]
+
+  return (
+    <div className="space-y-6">
+      {/* Summary Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {[
+          { label: 'Total emisiones', value: `${summary.total.toLocaleString('es-ES', { maximumFractionDigits: 1 })}`, unit: 'tCO2e' },
+          { label: 'Scope 1', value: `${summary.scope_1.toLocaleString('es-ES', { maximumFractionDigits: 1 })}`, unit: 'tCO2e' },
+          { label: 'Scope 2 (LBM)', value: `${summary.scope_2_lbm.toLocaleString('es-ES', { maximumFractionDigits: 1 })}`, unit: 'tCO2e' },
+          { label: 'Fuentes analizadas', value: results.length, unit: '' },
+        ].map((card, i) => (
+          <div key={i} className="border border-sovereign-silver p-4">
+            <p className="text-label uppercase text-slate">{card.label}</p>
+            <p className="font-mono text-metric text-navy mt-1">{card.value}</p>
+            {card.unit && <p className="text-xs text-slate">{card.unit}</p>}
+          </div>
+        ))}
+      </div>
+
+      {/* Scope Distribution */}
+      <div className="border border-sovereign-silver p-6">
+        <h4 className="text-label uppercase text-slate mb-4">Distribución por Scope</h4>
+        <div className="space-y-3">
+          <ScopeBar label="Scope 1" value={summary.scope_1} total={summary.total} color="bg-navy" />
+          <ScopeBar label="Scope 2 (LBM)" value={summary.scope_2_lbm} total={summary.total} color="bg-navy-600" />
+          {summary.scope_3 > 0 && (
+            <ScopeBar label="Scope 3" value={summary.scope_3} total={summary.total} color="bg-navy-400" />
+          )}
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="border-b-2 border-navy flex gap-0">
+        {tabs.map(tab => (
+          <button key={tab.id} onClick={() => setActiveTab(tab.id)}
+            className={`text-label uppercase px-6 py-3 transition-colors ${
+              activeTab === tab.id
+                ? 'bg-navy text-white'
+                : 'text-slate hover:text-navy'
+            }`}>
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab: Inventario */}
+      {activeTab === 'inventario' && (
+        <div>
+          <div className="flex justify-between items-center mb-4">
+            <h4 className="font-serif text-lg text-navy">Resultado del Cálculo de Emisiones</h4>
+            <button onClick={exportInventory}
+              className="text-label uppercase px-4 py-2 border border-sovereign-silver text-slate hover:text-navy hover:border-navy transition-colors">
+              Descargar CSV
+            </button>
+          </div>
+          <div className="overflow-x-auto border border-sovereign-silver">
+            <table className="w-full sovereign-table text-sm">
+              <thead>
+                <tr className="bg-sovereign-ash">
+                  <th>Fuente de Emisión</th>
+                  <th>Scope</th>
+                  <th>Categoría</th>
+                  <th className="text-right">Dato Actividad</th>
+                  <th className="text-right">Factor (kg/u)</th>
+                  <th className="text-right">GWP</th>
+                  <th className="text-right">tCO2e</th>
+                  <th className="text-right">% Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[...results].sort((a, b) => b.tCO2e - a.tCO2e).map(r => (
+                  <tr key={r.id}>
+                    <td className="font-medium">{r.nombre}</td>
+                    <td><span className={`inline-block px-2 py-0.5 text-xs font-mono ${
+                      r.scope === 1 ? 'bg-navy text-white' : r.scope === 2 ? 'bg-navy-600 text-white' : 'bg-navy-400 text-white'
+                    }`}>Scope {r.scope}</span></td>
+                    <td className="text-slate">{r.categoria.replace(/_/g, ' ')}</td>
+                    <td className="text-right font-mono">{r.cantidad.toLocaleString('es-ES')}</td>
+                    <td className="text-right font-mono">{r.factor_emision}</td>
+                    <td className="text-right font-mono">{r.gwp}</td>
+                    <td className="text-right font-mono font-medium">{r.tCO2e.toLocaleString('es-ES', { maximumFractionDigits: 1 })}</td>
+                    <td className="text-right font-mono text-slate">{((r.tCO2e / summary.total) * 100).toFixed(1)}%</td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot>
+                <tr className="border-t-2 border-navy bg-sovereign-ash">
+                  <td colSpan={6} className="font-semibold text-navy">TOTAL</td>
+                  <td className="text-right font-mono font-bold text-navy">{summary.total.toLocaleString('es-ES', { maximumFractionDigits: 1 })}</td>
+                  <td className="text-right font-mono font-bold text-navy">100%</td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Tab: Diagnóstico */}
+      {activeTab === 'diagnostico' && diagnostic && (
+        <div className="space-y-6">
+          <h4 className="font-serif text-lg text-navy">Fuentes Prioritarias (Fase 2 — Diagnóstico)</h4>
+          <div className="space-y-4">
+            {diagnostic.priorities.map((p, i) => (
+              <div key={i} className="border border-sovereign-silver p-4">
+                <div className="flex items-start justify-between">
+                  <div>
+                    <span className="text-label uppercase text-slate">#{i + 1}</span>
+                    <h5 className="font-medium text-navy">{p.nombre}</h5>
+                    <p className="text-sm text-slate">Scope {p.scope} — {p.porcentaje}% del total</p>
+                  </div>
+                  <div className="text-right">
+                    <p className="font-mono text-xl text-navy">{p.tCO2e.toLocaleString('es-ES', { maximumFractionDigits: 1 })}</p>
+                    <p className="text-xs text-slate">tCO2e</p>
+                  </div>
+                </div>
+                <div className="mt-3 pt-3 border-t border-sovereign-silver">
+                  <p className="text-label uppercase text-slate mb-2">Alternativas sugeridas:</p>
+                  <div className="space-y-1">
+                    {p.alternatives.map((alt, j) => (
+                      <div key={j} className="flex items-center gap-3 text-sm">
+                        <span className={`text-xs px-2 py-0.5 ${
+                          alt.horizonte === 'Corto plazo' ? 'bg-status-active text-white' :
+                          alt.horizonte === 'Medio plazo' ? 'bg-status-pending text-white' :
+                          'bg-navy-400 text-white'
+                        }`}>{alt.horizonte}</span>
+                        <span className="text-charcoal">{alt.medida}</span>
+                        <span className="text-xs text-slate ml-auto">{alt.palanca}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Trajectory */}
+          {diagnostic.trajectory && (
+            <div className="border border-sovereign-silver p-6">
+              <h4 className="text-label uppercase text-slate mb-3">Trayectoria de Reducción (SBTi 1.5°C)</h4>
+              <div className="flex items-end gap-1 h-40">
+                {Object.entries(diagnostic.trajectory).sort(([a], [b]) => a - b).map(([year, value]) => {
+                  const maxVal = Math.max(...Object.values(diagnostic.trajectory))
+                  const heightPct = maxVal > 0 ? (value / maxVal) * 100 : 0
+                  return (
+                    <div key={year} className="flex-1 flex flex-col items-center gap-1">
+                      <span className="text-xs font-mono text-navy">{value.toLocaleString('es-ES', { maximumFractionDigits: 0 })}</span>
+                      <div className="w-full bg-navy" style={{ height: `${heightPct}%`, minHeight: '4px' }} />
+                      <span className="text-xs text-slate">{year}</span>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Tab: Medidas */}
+      {activeTab === 'medidas' && (
+        <div>
+          <div className="flex justify-between items-center mb-4">
+            <h4 className="font-serif text-lg text-navy">Medidas de Reducción (Fase 3 + Fase 4)</h4>
+            <div className="flex gap-2">
+              <button onClick={applyDefaultCosts}
+                className="text-label uppercase px-4 py-2 border border-sovereign-silver text-slate hover:text-navy hover:border-navy transition-colors">
+                Auto-asignar Costes
+              </button>
+              <button onClick={exportMeasures}
+                className="text-label uppercase px-4 py-2 border border-sovereign-silver text-slate hover:text-navy hover:border-navy transition-colors">
+                Descargar CSV
+              </button>
+            </div>
+          </div>
+
+          <p className="text-sm text-slate mb-4">
+            Edite CAPEX y Ahorro anual para cada medida. Se calcularán automáticamente el Coste Neto y MACC.
+          </p>
+
+          <div className="overflow-x-auto border border-sovereign-silver">
+            <table className="w-full sovereign-table text-sm">
+              <thead>
+                <tr className="bg-sovereign-ash">
+                  <th>ID</th>
+                  <th>Medida</th>
+                  <th>Fuente</th>
+                  <th>Horizonte</th>
+                  <th className="text-right">tCO2e/año</th>
+                  <th className="text-right">Vida útil</th>
+                  <th className="text-right">CAPEX (€)</th>
+                  <th className="text-right">Ahorro/año (€)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {measures.map((m, i) => (
+                  <tr key={m.id}>
+                    <td className="font-mono text-xs text-slate">{m.id}</td>
+                    <td className="font-medium">{m.nombre}</td>
+                    <td className="text-slate text-xs">{m.source_nombre}</td>
+                    <td>
+                      <span className={`text-xs px-2 py-0.5 ${
+                        m.horizonte === 'Corto plazo' ? 'bg-status-active text-white' :
+                        m.horizonte === 'Medio plazo' ? 'bg-status-pending text-white' :
+                        'bg-navy-400 text-white'
+                      }`}>{m.horizonte}</span>
+                    </td>
+                    <td className="text-right font-mono">{m.tCO2e_anuales}</td>
+                    <td className="text-right font-mono">{m.vida_util_anios}</td>
+                    <td className="text-right">
+                      <input type="number" value={m.capex_eur}
+                        onChange={e => updateMeasure(i, 'capex_eur', parseFloat(e.target.value) || 0)}
+                        className="w-28 border border-sovereign-silver px-2 py-1 text-right font-mono text-sm focus:border-navy focus:outline-none" />
+                    </td>
+                    <td className="text-right">
+                      <input type="number" value={m.ahorro_anual_eur}
+                        onChange={e => updateMeasure(i, 'ahorro_anual_eur', parseFloat(e.target.value) || 0)}
+                        className="w-28 border border-sovereign-silver px-2 py-1 text-right font-mono text-sm focus:border-navy focus:outline-none" />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Proceed to Report */}
+      <div className="flex justify-end pt-4 border-t border-sovereign-silver">
+        <button
+          disabled={!hasCosts}
+          onClick={onGenerateReport}
+          className={`text-label uppercase px-8 py-3 transition-colors ${
+            hasCosts
+              ? 'bg-navy text-white hover:bg-navy-800'
+              : 'bg-sovereign-silver text-slate cursor-not-allowed'
+          }`}
+        >
+          Generar Informe de Descarbonización →
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/decarb/DecarbonizationTool.jsx
+++ b/src/components/decarb/DecarbonizationTool.jsx
@@ -1,0 +1,155 @@
+import React, { useState } from 'react'
+import FileUploadPanel from './FileUploadPanel'
+import CalculationTable from './CalculationTable'
+import ReportOutput from './ReportOutput'
+import {
+  calculateEmissions, summarizeByScope,
+  runDiagnostic, buildPathway, calculateMACC,
+  autoAssignCosts,
+} from '../../lib/decarbEngine'
+
+const STEPS = [
+  { id: 'input', label: '1. Inventario', desc: 'Carga de datos' },
+  { id: 'calculate', label: '2. Cálculo', desc: 'Análisis y medidas' },
+  { id: 'report', label: '3. Informe', desc: 'Plan de descarbonización' },
+]
+
+export default function DecarbonizationTool({ onClose }) {
+  const [step, setStep] = useState('input')
+  const [sources, setSources] = useState([])
+  const [orgData, setOrgData] = useState({})
+  const [results, setResults] = useState([])
+  const [summary, setSummary] = useState(null)
+  const [diagnostic, setDiagnostic] = useState(null)
+  const [measures, setMeasures] = useState([])
+  const [macc, setMacc] = useState(null)
+
+  const handleDataLoaded = (data) => {
+    setOrgData(data.org)
+    const consolidation = parseFloat(data.org.consolidacion) || 100
+    const calcResults = calculateEmissions(data.sources, consolidation)
+    const calcSummary = summarizeByScope(calcResults)
+    const calcDiag = runDiagnostic(calcResults, 42, parseInt(data.org.anio) || 2023, 2030)
+    const calcMeasures = buildPathway(calcDiag)
+    const withCosts = autoAssignCosts(calcMeasures)
+
+    setResults(calcResults)
+    setSummary(calcSummary)
+    setDiagnostic(calcDiag)
+    setMeasures(withCosts)
+    setStep('calculate')
+  }
+
+  const handleGenerateReport = () => {
+    const calcMacc = calculateMACC(measures)
+    setMacc(calcMacc)
+    setStep('report')
+  }
+
+  const goBack = () => {
+    if (step === 'report') setStep('calculate')
+    else if (step === 'calculate') setStep('input')
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 bg-white flex flex-col">
+      {/* Header */}
+      <div className="border-b border-sovereign-silver">
+        <div className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <button onClick={onClose} className="text-slate hover:text-navy transition-colors" aria-label="Cerrar">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <path d="M19 12H5M12 19l-7-7 7-7" />
+              </svg>
+            </button>
+            <div>
+              <h1 className="font-serif text-2xl text-navy leading-none">Herramienta de Descarbonización</h1>
+              <p className="text-xs text-slate mt-0.5">GHG Protocol · SBTi 1.5°C · MACC Analysis</p>
+            </div>
+          </div>
+          <a href="#" onClick={e => { e.preventDefault(); onClose() }}
+            className="flex items-baseline gap-1">
+            <span className="font-serif text-2xl font-bold text-navy">ESW</span>
+          </a>
+        </div>
+      </div>
+
+      {/* Step Indicator */}
+      <div className="border-b border-sovereign-silver bg-sovereign-ash">
+        <div className="max-w-7xl mx-auto px-6 py-3 flex items-center gap-0">
+          {STEPS.map((s, i) => {
+            const isActive = s.id === step
+            const isPast = STEPS.findIndex(x => x.id === step) > i
+            return (
+              <React.Fragment key={s.id}>
+                {i > 0 && <div className={`w-12 h-px mx-2 ${isPast ? 'bg-navy' : 'bg-sovereign-silver'}`} />}
+                <button
+                  onClick={() => {
+                    if (isPast) setStep(s.id)
+                  }}
+                  className={`flex items-center gap-2 px-4 py-2 transition-colors ${
+                    isActive ? 'bg-navy text-white' :
+                    isPast ? 'text-navy cursor-pointer hover:bg-navy-50' :
+                    'text-slate cursor-default'
+                  }`}
+                >
+                  <span className={`w-6 h-6 flex items-center justify-center text-xs font-mono ${
+                    isActive ? 'bg-white text-navy' : isPast ? 'bg-navy text-white' : 'bg-sovereign-silver text-slate'
+                  }`}>{i + 1}</span>
+                  <div className="text-left">
+                    <p className="text-label uppercase leading-none">{s.label}</p>
+                    <p className="text-[10px] opacity-70">{s.desc}</p>
+                  </div>
+                </button>
+              </React.Fragment>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto">
+        <div className="max-w-7xl mx-auto px-6 py-8">
+          {step !== 'input' && (
+            <button onClick={goBack}
+              className="text-label uppercase text-slate hover:text-navy mb-6 flex items-center gap-1 transition-colors">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <path d="M19 12H5M12 19l-7-7 7-7" />
+              </svg>
+              Volver al paso anterior
+            </button>
+          )}
+
+          {step === 'input' && (
+            <FileUploadPanel
+              onDataLoaded={handleDataLoaded}
+              sources={sources}
+              setSources={setSources}
+            />
+          )}
+
+          {step === 'calculate' && summary && (
+            <CalculationTable
+              results={results}
+              summary={summary}
+              diagnostic={diagnostic}
+              measures={measures}
+              setMeasures={setMeasures}
+              onGenerateReport={handleGenerateReport}
+            />
+          )}
+
+          {step === 'report' && macc && (
+            <ReportOutput
+              orgData={orgData}
+              summary={summary}
+              diagnostic={diagnostic}
+              macc={macc}
+              results={results}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/decarb/FileUploadPanel.jsx
+++ b/src/components/decarb/FileUploadPanel.jsx
@@ -1,0 +1,293 @@
+import React, { useRef, useState } from 'react'
+import { parseCSV } from '../../lib/decarbEngine'
+
+const TEMPLATE_HEADERS = [
+  'nombre', 'descripcion', 'scope', 'categoria', 'cantidad', 'unidad', 'factor_key'
+]
+
+const TEMPLATE_ROWS = [
+  ['Electricidad planta', 'Consumo anual red eléctrica', '2', 'electricidad_comprada', '4500000', 'kWh', 'electricidad_kwh'],
+  ['Calderas gas natural', 'Proceso térmico industrial', '1', 'caldera_gas_natural', '800000', 'm3', 'gas_natural_m3'],
+  ['Flota diésel', 'Vehículos de distribución', '1', 'transporte_flota', '450000', 'litros', 'diesel_litros'],
+  ['Refrigeración', 'Fugas R-410A', '1', 'refrigeracion_fugitivas', '150', 'kg', 'r410a_kg'],
+]
+
+const FACTOR_OPTIONS = [
+  { key: 'electricidad_kwh', label: 'Electricidad (kWh)' },
+  { key: 'gas_natural_m3', label: 'Gas natural (m³)' },
+  { key: 'gas_natural_kwh', label: 'Gas natural (kWh)' },
+  { key: 'diesel_litros', label: 'Diésel (litros)' },
+  { key: 'gasolina_litros', label: 'Gasolina (litros)' },
+  { key: 'fueloil_litros', label: 'Fuelóil (litros)' },
+  { key: 'glp_litros', label: 'GLP (litros)' },
+  { key: 'r410a_kg', label: 'R-410A (kg)' },
+  { key: 'r134a_kg', label: 'R-134a (kg)' },
+  { key: 'r404a_kg', label: 'R-404A (kg)' },
+]
+
+const SCOPE_OPTIONS = [
+  { value: 1, label: 'Scope 1 — Directas' },
+  { value: 2, label: 'Scope 2 — Indirectas (energía)' },
+  { value: 3, label: 'Scope 3 — Otras indirectas' },
+]
+
+const CATEGORY_OPTIONS = [
+  'electricidad_comprada', 'caldera_gas_natural', 'transporte_flota',
+  'refrigeracion_fugitivas', 'generacion_electrica', 'proceso_industrial',
+  'vehiculo_empresa', 'otro',
+]
+
+export default function FileUploadPanel({ onDataLoaded, sources, setSources }) {
+  const fileRef = useRef(null)
+  const [dragOver, setDragOver] = useState(false)
+  const [fileName, setFileName] = useState('')
+  const [error, setError] = useState('')
+  const [orgData, setOrgData] = useState({
+    nombre: '', pais: 'España', sector: '', empleados: '', ingresos: '', anio: '2023',
+    consolidacion: '100',
+  })
+
+  const handleFile = (file) => {
+    if (!file) return
+    setError('')
+    setFileName(file.name)
+
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      try {
+        const text = e.target.result
+        const parsed = parseCSV(text)
+        if (parsed.length === 0) {
+          setError('El archivo no contiene datos válidos.')
+          return
+        }
+        const mapped = parsed.map((row, i) => ({
+          id: `SRC-${String(i + 1).padStart(3, '0')}`,
+          nombre: row.nombre || row.name || `Fuente ${i + 1}`,
+          descripcion: row.descripcion || row.description || '',
+          scope: parseInt(row.scope) || 1,
+          categoria: row.categoria || row.category || 'otro',
+          cantidad: parseFloat(row.cantidad || row.quantity || row.amount) || 0,
+          unidad: row.unidad || row.unit || '',
+          factor_key: row.factor_key || row.factor || '',
+          scope2_method: row.scope2_method || 'LBM',
+        }))
+        setSources(mapped)
+      } catch {
+        setError('Error al procesar el archivo. Verifique el formato CSV.')
+      }
+    }
+    reader.readAsText(file)
+  }
+
+  const handleDrop = (e) => {
+    e.preventDefault()
+    setDragOver(false)
+    const file = e.dataTransfer.files[0]
+    handleFile(file)
+  }
+
+  const downloadTemplate = () => {
+    const csv = '\uFEFF' + TEMPLATE_HEADERS.join(';') + '\n' +
+      TEMPLATE_ROWS.map(r => r.join(';')).join('\n')
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'plantilla_inventario_GEI.csv'
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+  }
+
+  const loadDemo = () => {
+    setOrgData({
+      nombre: 'Industrias Verdes S.A.', pais: 'España', sector: 'Manufactura',
+      empleados: '500', ingresos: '85000000', anio: '2023', consolidacion: '100',
+    })
+    setSources(TEMPLATE_ROWS.map((r, i) => ({
+      id: `SRC-${String(i + 1).padStart(3, '0')}`,
+      nombre: r[0], descripcion: r[1], scope: parseInt(r[2]),
+      categoria: r[3], cantidad: parseFloat(r[4]),
+      unidad: r[5], factor_key: r[6], scope2_method: 'LBM',
+    })))
+    setFileName('demo_data.csv')
+  }
+
+  const addSource = () => {
+    const newId = `SRC-${String(sources.length + 1).padStart(3, '0')}`
+    setSources([...sources, {
+      id: newId, nombre: '', descripcion: '', scope: 1,
+      categoria: 'otro', cantidad: 0, unidad: '', factor_key: '', scope2_method: 'LBM',
+    }])
+  }
+
+  const updateSource = (index, field, value) => {
+    const updated = [...sources]
+    updated[index] = { ...updated[index], [field]: value }
+    setSources(updated)
+  }
+
+  const removeSource = (index) => {
+    setSources(sources.filter((_, i) => i !== index))
+  }
+
+  const canProceed = sources.length > 0 && sources.some(s => s.cantidad > 0 && s.factor_key)
+
+  return (
+    <div className="space-y-8">
+      {/* Organization Data */}
+      <div>
+        <h3 className="font-serif text-xl text-navy mb-4">A. Datos de la Organización</h3>
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+          {[
+            { key: 'nombre', label: 'Nombre', type: 'text', span: 2 },
+            { key: 'pais', label: 'País', type: 'text' },
+            { key: 'sector', label: 'Sector', type: 'text' },
+            { key: 'empleados', label: 'Empleados', type: 'number' },
+            { key: 'ingresos', label: 'Ingresos (€)', type: 'number' },
+            { key: 'anio', label: 'Año reporte', type: 'number' },
+            { key: 'consolidacion', label: 'Consolidación (%)', type: 'number' },
+          ].map(f => (
+            <div key={f.key} className={f.span ? `col-span-${f.span}` : ''}>
+              <label className="text-label uppercase text-slate block mb-1">{f.label}</label>
+              <input
+                type={f.type}
+                value={orgData[f.key]}
+                onChange={e => setOrgData({ ...orgData, [f.key]: e.target.value })}
+                className="w-full border border-sovereign-silver px-3 py-2 text-sm text-charcoal focus:border-navy focus:outline-none bg-white"
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* File Upload */}
+      <div>
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="font-serif text-xl text-navy">B. Carga de Datos de Actividad</h3>
+          <div className="flex gap-2">
+            <button onClick={downloadTemplate}
+              className="text-label uppercase px-4 py-2 border border-sovereign-silver text-slate hover:text-navy hover:border-navy transition-colors">
+              Descargar Plantilla
+            </button>
+            <button onClick={loadDemo}
+              className="text-label uppercase px-4 py-2 bg-navy text-white hover:bg-navy-800 transition-colors">
+              Cargar Demo
+            </button>
+          </div>
+        </div>
+
+        <div
+          onDragOver={e => { e.preventDefault(); setDragOver(true) }}
+          onDragLeave={() => setDragOver(false)}
+          onDrop={handleDrop}
+          onClick={() => fileRef.current?.click()}
+          className={`border-2 border-dashed p-8 text-center cursor-pointer transition-colors ${
+            dragOver ? 'border-navy bg-navy-50' : 'border-sovereign-silver hover:border-navy'
+          }`}
+        >
+          <input ref={fileRef} type="file" accept=".csv,.txt" className="hidden"
+            onChange={e => handleFile(e.target.files[0])} />
+          <svg className="w-8 h-8 mx-auto mb-3 text-slate" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
+          </svg>
+          {fileName ? (
+            <p className="text-sm text-navy font-medium">{fileName} — {sources.length} fuentes cargadas</p>
+          ) : (
+            <>
+              <p className="text-sm text-charcoal">Arrastre su archivo CSV aquí o haga clic para seleccionar</p>
+              <p className="text-xs text-slate mt-1">Formato: nombre;scope;categoria;cantidad;unidad;factor_key</p>
+            </>
+          )}
+        </div>
+        {error && <p className="text-sm text-status-blocked mt-2">{error}</p>}
+      </div>
+
+      {/* Manual Source Table */}
+      {sources.length > 0 && (
+        <div>
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="font-serif text-xl text-navy">C. Fuentes de Emisión ({sources.length})</h3>
+            <button onClick={addSource}
+              className="text-label uppercase px-4 py-2 border border-sovereign-silver text-slate hover:text-navy hover:border-navy transition-colors">
+              + Añadir Fuente
+            </button>
+          </div>
+
+          <div className="overflow-x-auto border border-sovereign-silver">
+            <table className="w-full sovereign-table text-sm">
+              <thead>
+                <tr className="bg-sovereign-ash">
+                  <th className="w-8"></th>
+                  <th>Nombre</th>
+                  <th>Scope</th>
+                  <th>Categoría</th>
+                  <th>Cantidad</th>
+                  <th>Unidad</th>
+                  <th>Factor de Emisión</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sources.map((src, i) => (
+                  <tr key={src.id}>
+                    <td className="text-center">
+                      <button onClick={() => removeSource(i)} className="text-slate hover:text-status-blocked text-xs">
+                        ×
+                      </button>
+                    </td>
+                    <td>
+                      <input value={src.nombre} onChange={e => updateSource(i, 'nombre', e.target.value)}
+                        className="w-full border-0 bg-transparent text-sm focus:outline-none" />
+                    </td>
+                    <td>
+                      <select value={src.scope} onChange={e => updateSource(i, 'scope', parseInt(e.target.value))}
+                        className="w-full border-0 bg-transparent text-sm focus:outline-none">
+                        {SCOPE_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                      </select>
+                    </td>
+                    <td>
+                      <select value={src.categoria} onChange={e => updateSource(i, 'categoria', e.target.value)}
+                        className="w-full border-0 bg-transparent text-sm focus:outline-none">
+                        {CATEGORY_OPTIONS.map(c => <option key={c} value={c}>{c.replace(/_/g, ' ')}</option>)}
+                      </select>
+                    </td>
+                    <td>
+                      <input type="number" value={src.cantidad}
+                        onChange={e => updateSource(i, 'cantidad', parseFloat(e.target.value) || 0)}
+                        className="w-full border-0 bg-transparent text-sm text-right font-mono focus:outline-none" />
+                    </td>
+                    <td className="text-xs text-slate">{src.unidad || '—'}</td>
+                    <td>
+                      <select value={src.factor_key} onChange={e => updateSource(i, 'factor_key', e.target.value)}
+                        className="w-full border-0 bg-transparent text-sm focus:outline-none">
+                        <option value="">Seleccionar...</option>
+                        {FACTOR_OPTIONS.map(o => <option key={o.key} value={o.key}>{o.label}</option>)}
+                      </select>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Proceed */}
+      <div className="flex justify-end pt-4 border-t border-sovereign-silver">
+        <button
+          disabled={!canProceed}
+          onClick={() => onDataLoaded({ org: orgData, sources })}
+          className={`text-label uppercase px-8 py-3 transition-colors ${
+            canProceed
+              ? 'bg-navy text-white hover:bg-navy-800'
+              : 'bg-sovereign-silver text-slate cursor-not-allowed'
+          }`}
+        >
+          Calcular Emisiones →
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/decarb/ReportOutput.jsx
+++ b/src/components/decarb/ReportOutput.jsx
@@ -1,0 +1,290 @@
+import React, { useRef } from 'react'
+
+function MACCBar({ entry, maxAbsMACC }) {
+  const barHeight = maxAbsMACC > 0 ? Math.abs(entry.macc_eur_tCO2e) / maxAbsMACC * 100 : 0
+  const isNegative = entry.macc_eur_tCO2e < 0
+  return (
+    <div className="flex flex-col items-center flex-1 min-w-[60px]" title={`${entry.nombre}\n${entry.macc_eur_tCO2e} €/tCO2e`}>
+      {/* Positive area */}
+      <div className="h-24 w-full flex items-end justify-center">
+        {!isNegative && (
+          <div className="w-4/5 bg-status-blocked opacity-70" style={{ height: `${barHeight}%`, minHeight: barHeight > 0 ? '2px' : '0' }} />
+        )}
+      </div>
+      {/* Zero line */}
+      <div className="w-full h-px bg-navy" />
+      {/* Negative area (savings) */}
+      <div className="h-24 w-full flex items-start justify-center">
+        {isNegative && (
+          <div className="w-4/5 bg-status-active opacity-70" style={{ height: `${barHeight}%`, minHeight: barHeight > 0 ? '2px' : '0' }} />
+        )}
+      </div>
+      <span className="text-[9px] text-slate mt-1 text-center leading-tight truncate w-full px-0.5">
+        {entry.nombre.length > 20 ? entry.nombre.slice(0, 20) + '…' : entry.nombre}
+      </span>
+    </div>
+  )
+}
+
+export default function ReportOutput({ orgData, summary, diagnostic, macc, results }) {
+  const reportRef = useRef(null)
+
+  const downloadPDF = () => {
+    const el = reportRef.current
+    if (!el) return
+    const printWindow = window.open('', '_blank')
+    printWindow.document.write(`
+      <!DOCTYPE html>
+      <html><head>
+        <title>Informe de Descarbonización — ${orgData.nombre || 'ESW'}</title>
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=EB+Garamond:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+        <style>
+          * { margin: 0; padding: 0; box-sizing: border-box; }
+          body { font-family: 'Inter', sans-serif; color: #1E293B; font-size: 11px; line-height: 1.5; padding: 30px; }
+          h1 { font-family: 'EB Garamond', serif; font-size: 28px; color: #0A1628; margin-bottom: 4px; }
+          h2 { font-family: 'EB Garamond', serif; font-size: 18px; color: #0A1628; margin: 24px 0 8px; border-bottom: 2px solid #0A1628; padding-bottom: 4px; }
+          h3 { font-size: 13px; font-weight: 600; color: #0A1628; margin: 16px 0 6px; text-transform: uppercase; letter-spacing: 0.05em; }
+          .subtitle { font-size: 12px; color: #5A6577; margin-bottom: 20px; }
+          .metric-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin: 16px 0; }
+          .metric-card { border: 1px solid #E2E5EA; padding: 12px; }
+          .metric-label { font-size: 9px; text-transform: uppercase; letter-spacing: 0.08em; color: #5A6577; }
+          .metric-value { font-family: 'JetBrains Mono', monospace; font-size: 22px; color: #0A1628; }
+          .metric-unit { font-size: 10px; color: #5A6577; }
+          table { width: 100%; border-collapse: collapse; font-size: 10px; margin: 8px 0; }
+          th { background: #F4F5F7; font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #5A6577; text-align: left; padding: 6px 8px; border-bottom: 2px solid #0A1628; }
+          td { padding: 5px 8px; border-bottom: 1px solid #E2E5EA; }
+          .text-right { text-align: right; }
+          .mono { font-family: 'JetBrains Mono', monospace; }
+          .badge { display: inline-block; padding: 1px 6px; font-size: 9px; color: white; }
+          .badge-green { background: #1B5E20; }
+          .badge-amber { background: #B45309; }
+          .badge-blue { background: #415580; }
+          .badge-navy { background: #0A1628; }
+          .roadmap-phase { margin: 12px 0; padding: 12px; border: 1px solid #E2E5EA; }
+          .roadmap-title { font-weight: 600; color: #0A1628; font-size: 12px; }
+          .footer { margin-top: 40px; padding-top: 12px; border-top: 2px solid #0A1628; font-size: 9px; color: #5A6577; display: flex; justify-content: space-between; }
+          .positive { color: #991B1B; }
+          .negative { color: #1B5E20; }
+          .page-break { page-break-before: always; }
+          @media print { body { padding: 20px; } .page-break { page-break-before: always; } }
+        </style>
+      </head><body>
+        ${el.innerHTML}
+      </body></html>
+    `)
+    printWindow.document.close()
+    setTimeout(() => {
+      printWindow.print()
+    }, 500)
+  }
+
+  const maxAbsMACC = macc.ranking.length > 0
+    ? Math.max(...macc.ranking.map(e => Math.abs(e.macc_eur_tCO2e)))
+    : 1
+
+  return (
+    <div className="space-y-6">
+      {/* Download button */}
+      <div className="flex justify-between items-center">
+        <h3 className="font-serif text-xl text-navy">Informe de Descarbonización</h3>
+        <button onClick={downloadPDF}
+          className="text-label uppercase px-6 py-3 bg-navy text-white hover:bg-navy-800 transition-colors">
+          Descargar PDF
+        </button>
+      </div>
+
+      {/* Report content */}
+      <div ref={reportRef} className="bg-white border border-sovereign-silver p-8 space-y-6">
+
+        {/* Header */}
+        <div>
+          <h1 className="font-serif text-3xl text-navy">Plan de Descarbonización</h1>
+          <p className="text-sm text-slate">{orgData.nombre || 'Organización'} — {orgData.pais} — {orgData.sector} — Año base: {orgData.anio}</p>
+          <p className="text-xs text-slate mt-1">Metodología: GHG Protocol Corporate Standard | Objetivo: SBTi 1.5°C ({diagnostic.targetPct}% reducción para {Math.max(...Object.keys(diagnostic.trajectory || { 2030: 0 }).map(Number))})</p>
+        </div>
+
+        {/* KPIs */}
+        <div>
+          <h2 className="font-serif text-xl text-navy border-b-2 border-navy pb-1 mb-4">Resumen Ejecutivo</h2>
+          <div className="metric-grid grid grid-cols-2 md:grid-cols-4 gap-4">
+            {[
+              { label: 'Emisiones base', value: summary.total.toLocaleString('es-ES', { maximumFractionDigits: 1 }), unit: 'tCO2e' },
+              { label: 'Reducción acumulada', value: macc.reduccion_total_tCO2e.toLocaleString('es-ES', { maximumFractionDigits: 1 }), unit: 'tCO2e (vida útil)' },
+              { label: 'Inversión total', value: macc.inversion_total_eur.toLocaleString('es-ES'), unit: '€' },
+              { label: 'Coste medio', value: macc.coste_medio.toLocaleString('es-ES', { maximumFractionDigits: 2 }), unit: '€/tCO2e' },
+            ].map((m, i) => (
+              <div key={i} className="border border-sovereign-silver p-3">
+                <p className="text-label uppercase text-slate text-xs">{m.label}</p>
+                <p className="font-mono text-2xl text-navy">{m.value}</p>
+                <p className="text-xs text-slate">{m.unit}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Scope breakdown */}
+        <div>
+          <h2 className="font-serif text-xl text-navy border-b-2 border-navy pb-1 mb-4">Inventario de Emisiones GEI</h2>
+          <table className="w-full sovereign-table text-sm">
+            <thead>
+              <tr className="bg-sovereign-ash">
+                <th>Fuente de Emisión</th>
+                <th>Scope</th>
+                <th className="text-right">tCO2e</th>
+                <th className="text-right">% Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {[...results].sort((a, b) => b.tCO2e - a.tCO2e).map(r => (
+                <tr key={r.id}>
+                  <td>{r.nombre}</td>
+                  <td><span className={`inline-block px-2 py-0.5 text-xs text-white ${
+                    r.scope === 1 ? 'badge-navy bg-navy' : r.scope === 2 ? 'bg-navy-600' : 'bg-navy-400'
+                  }`}>Scope {r.scope}</span></td>
+                  <td className="text-right font-mono">{r.tCO2e.toLocaleString('es-ES', { maximumFractionDigits: 1 })}</td>
+                  <td className="text-right font-mono text-slate">{((r.tCO2e / summary.total) * 100).toFixed(1)}%</td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr className="border-t-2 border-navy">
+                <td colSpan={2} className="font-semibold text-navy">TOTAL</td>
+                <td className="text-right font-mono font-bold text-navy">{summary.total.toLocaleString('es-ES', { maximumFractionDigits: 1 })}</td>
+                <td className="text-right font-mono font-bold text-navy">100%</td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+
+        {/* Trajectory */}
+        {diagnostic.trajectory && (
+          <div>
+            <h2 className="font-serif text-xl text-navy border-b-2 border-navy pb-1 mb-4">Senda de Descarbonización (SBTi 1.5°C)</h2>
+            <table className="w-full sovereign-table text-sm">
+              <thead>
+                <tr className="bg-sovereign-ash">
+                  <th>Año</th>
+                  <th className="text-right">Objetivo (tCO2e)</th>
+                  <th className="text-right">Reducción vs. base</th>
+                </tr>
+              </thead>
+              <tbody>
+                {Object.entries(diagnostic.trajectory).sort(([a], [b]) => a - b).map(([year, value]) => (
+                  <tr key={year}>
+                    <td className="font-mono">{year}</td>
+                    <td className="text-right font-mono">{value.toLocaleString('es-ES', { maximumFractionDigits: 0 })}</td>
+                    <td className="text-right font-mono text-slate">
+                      {diagnostic.total > 0 ? `-${((1 - value / diagnostic.total) * 100).toFixed(1)}%` : '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* MACC Curve */}
+        <div>
+          <h2 className="font-serif text-xl text-navy border-b-2 border-navy pb-1 mb-4">Curva de Costes Marginales de Abatimiento (MACC)</h2>
+          <div className="border border-sovereign-silver p-4">
+            <div className="flex items-center gap-4 mb-2 text-xs text-slate">
+              <span className="flex items-center gap-1"><span className="w-3 h-3 bg-status-active opacity-70 inline-block" /> Ahorro neto (€/tCO2e &lt; 0)</span>
+              <span className="flex items-center gap-1"><span className="w-3 h-3 bg-status-blocked opacity-70 inline-block" /> Coste neto (€/tCO2e &gt; 0)</span>
+            </div>
+            <div className="flex items-stretch gap-0.5 px-2">
+              {macc.ranking.map((entry, i) => (
+                <MACCBar key={i} entry={entry} maxAbsMACC={maxAbsMACC} />
+              ))}
+            </div>
+            <div className="flex justify-between mt-2 text-xs text-slate">
+              <span>← Menor coste</span>
+              <span>tCO2e acumuladas →</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Ranking table */}
+        <div>
+          <h2 className="font-serif text-xl text-navy border-b-2 border-navy pb-1 mb-4">Ranking de Medidas</h2>
+          <table className="w-full sovereign-table text-sm">
+            <thead>
+              <tr className="bg-sovereign-ash">
+                <th>#</th>
+                <th>Medida</th>
+                <th>Horizonte</th>
+                <th className="text-right">tCO2e/año</th>
+                <th className="text-right">CAPEX (€)</th>
+                <th className="text-right">Coste Neto (€)</th>
+                <th className="text-right">MACC (€/tCO2e)</th>
+                <th className="text-right">Payback</th>
+              </tr>
+            </thead>
+            <tbody>
+              {macc.ranking.map((e, i) => (
+                <tr key={e.id}>
+                  <td className="font-mono text-slate">{i + 1}</td>
+                  <td className="font-medium">{e.nombre}</td>
+                  <td>
+                    <span className={`text-xs px-2 py-0.5 text-white ${
+                      e.horizonte === 'Corto plazo' ? 'bg-status-active' :
+                      e.horizonte === 'Medio plazo' ? 'bg-status-pending' : 'bg-navy-400'
+                    }`}>{e.horizonte}</span>
+                  </td>
+                  <td className="text-right font-mono">{e.tCO2e_anuales.toLocaleString('es-ES')}</td>
+                  <td className="text-right font-mono">{e.capex_eur.toLocaleString('es-ES')}</td>
+                  <td className={`text-right font-mono ${e.coste_neto_eur < 0 ? 'text-status-active' : 'text-status-blocked'}`}>
+                    {e.coste_neto_eur.toLocaleString('es-ES')}
+                  </td>
+                  <td className={`text-right font-mono font-medium ${e.macc_eur_tCO2e < 0 ? 'text-status-active' : 'text-status-blocked'}`}>
+                    {e.macc_eur_tCO2e.toLocaleString('es-ES', { maximumFractionDigits: 2 })}
+                  </td>
+                  <td className="text-right font-mono text-slate">
+                    {e.payback_anios === Infinity ? '—' : `${e.payback_anios} años`}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Roadmap */}
+        <div>
+          <h2 className="font-serif text-xl text-navy border-b-2 border-navy pb-1 mb-4">Roadmap de Implementación</h2>
+          {['Corto plazo', 'Medio plazo', 'Largo plazo'].map(horizonte => {
+            const items = macc.ranking.filter(e => e.horizonte === horizonte)
+            if (items.length === 0) return null
+            const investment = items.reduce((s, e) => s + e.capex_eur, 0)
+            const reduction = items.reduce((s, e) => s + e.tCO2e_anuales, 0)
+            return (
+              <div key={horizonte} className="border border-sovereign-silver p-4 mb-3">
+                <div className="flex justify-between items-center mb-2">
+                  <span className={`font-medium text-sm ${
+                    horizonte === 'Corto plazo' ? 'text-status-active' :
+                    horizonte === 'Medio plazo' ? 'text-status-pending' : 'text-navy-400'
+                  }`}>{horizonte}</span>
+                  <div className="text-right text-xs text-slate">
+                    <span className="font-mono">{investment.toLocaleString('es-ES')} €</span> inversión · <span className="font-mono">{reduction.toLocaleString('es-ES')} tCO2e/año</span>
+                  </div>
+                </div>
+                <ul className="space-y-1">
+                  {items.map(item => (
+                    <li key={item.id} className="text-sm text-charcoal flex justify-between">
+                      <span>· {item.nombre}</span>
+                      <span className="font-mono text-xs text-slate">{item.macc_eur_tCO2e.toLocaleString('es-ES', { maximumFractionDigits: 2 })} €/tCO2e</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )
+          })}
+        </div>
+
+        {/* Footer */}
+        <div className="border-t-2 border-navy pt-3 mt-8 flex justify-between text-xs text-slate">
+          <span>ESW — Ecosystem Services World · ecosystemservices.world</span>
+          <span>Generado: {new Date().toLocaleDateString('es-ES')} · Metodología: GHG Protocol + SBTi 1.5°C</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/decarbEngine.js
+++ b/src/lib/decarbEngine.js
@@ -1,0 +1,262 @@
+/**
+ * Decarbonization Engine — Client-side GHG Protocol calculations
+ *
+ * Mirrors the Python engine (agents/decarbonization/) for browser execution.
+ * All formulas from the technical specification:
+ *   Emisiones (tCO2e) = Dato_Actividad * Factor_Emision * GWP * Factor_Consolidacion
+ *   Coste_Neto = CAPEX - (Ahorro_Operativo_Anual * Vida_Util)
+ *   MACC = Coste_Neto / tCO2e_evitadas_acumuladas
+ */
+
+// ── Default emission factors (kgCO2e per unit) ──────────────────────
+const DEFAULT_FACTORS = {
+  electricidad_kwh: { factor: 0.150, gwp: 1.0, source: 'REE/MITECO 2023' },
+  gas_natural_m3: { factor: 2.0, gwp: 1.0, source: 'DEFRA 2023' },
+  gas_natural_kwh: { factor: 0.182, gwp: 1.0, source: 'DEFRA 2023' },
+  diesel_litros: { factor: 2.68, gwp: 1.0, source: 'DEFRA 2023' },
+  gasolina_litros: { factor: 2.31, gwp: 1.0, source: 'DEFRA 2023' },
+  fueloil_litros: { factor: 3.15, gwp: 1.0, source: 'DEFRA 2023' },
+  glp_litros: { factor: 1.56, gwp: 1.0, source: 'DEFRA 2023' },
+  r410a_kg: { factor: 1.0, gwp: 2088.0, source: 'IPCC AR6' },
+  r134a_kg: { factor: 1.0, gwp: 1430.0, source: 'IPCC AR6' },
+  r404a_kg: { factor: 1.0, gwp: 3922.0, source: 'IPCC AR6' },
+}
+
+// ── Phase 1: Calculate emissions ─────────────────────────────────────
+export function calculateEmissions(sources, consolidationPct = 100) {
+  const factor = consolidationPct / 100
+  return sources.map(src => {
+    const ef = DEFAULT_FACTORS[src.factor_key] || { factor: src.custom_factor || 0, gwp: src.custom_gwp || 1 }
+    const tCO2e = (src.cantidad * ef.factor * ef.gwp * factor) / 1000
+    return {
+      ...src,
+      tCO2e: Math.round(tCO2e * 100) / 100,
+      factor_emision: ef.factor,
+      gwp: ef.gwp,
+      factor_source: ef.source || 'Custom',
+    }
+  })
+}
+
+export function summarizeByScope(results) {
+  const summary = { scope_1: 0, scope_2_lbm: 0, scope_2_mbm: 0, scope_3: 0 }
+  results.forEach(r => {
+    if (r.scope === 1) summary.scope_1 += r.tCO2e
+    else if (r.scope === 2) {
+      if (r.scope2_method === 'MBM') summary.scope_2_mbm += r.tCO2e
+      else summary.scope_2_lbm += r.tCO2e
+    }
+    else if (r.scope === 3) summary.scope_3 += r.tCO2e
+  })
+  summary.total = summary.scope_1 + summary.scope_2_lbm + summary.scope_3
+  return summary
+}
+
+// ── Phase 2: Diagnostic — identify top sources ───────────────────────
+export function runDiagnostic(results, targetPct = 42, baseYear = 2023, targetYear = 2030) {
+  const total = results.reduce((sum, r) => sum + r.tCO2e, 0)
+  if (total <= 0) return { priorities: [], trajectory: {}, targetPct }
+
+  // Aggregate by source name
+  const bySource = {}
+  results.forEach(r => {
+    const key = r.nombre || r.id
+    if (!bySource[key]) bySource[key] = { ...r, tCO2e: 0 }
+    bySource[key].tCO2e += r.tCO2e
+  })
+
+  const ranked = Object.values(bySource).sort((a, b) => b.tCO2e - a.tCO2e)
+  let accumulated = 0
+  const priorities = []
+  for (const src of ranked) {
+    if (accumulated / total >= 0.80 && priorities.length >= 3) break
+    if (priorities.length >= 5) break
+    const pct = (src.tCO2e / total) * 100
+    priorities.push({
+      ...src,
+      porcentaje: Math.round(pct * 10) / 10,
+      alternatives: suggestAlternatives(src.categoria),
+      reduction_potential: estimateReduction(src.categoria, src.tCO2e),
+    })
+    accumulated += src.tCO2e
+  }
+
+  // Linear trajectory
+  const trajectory = {}
+  const horizonte = targetYear - baseYear
+  const tasa = targetPct / horizonte / 100
+  trajectory[baseYear] = Math.round(total * 10) / 10
+  const milestones = [baseYear + 2, 2025, 2030, 2035, targetYear]
+  milestones.forEach(yr => {
+    if (yr <= baseYear || yr > targetYear) return
+    const elapsed = yr - baseYear
+    trajectory[yr] = Math.round(total * Math.max(1 - tasa * elapsed, 0) * 10) / 10
+  })
+
+  return { priorities, trajectory, targetPct, total }
+}
+
+function suggestAlternatives(categoria) {
+  const cat = (categoria || '').toLowerCase()
+  if (cat.includes('electric') || cat.includes('grid') || cat.includes('comprada'))
+    return [
+      { medida: 'Contrato PPA de electricidad 100% renovable', palanca: 'Renovables', horizonte: 'Corto plazo' },
+      { medida: 'Instalación fotovoltaica de autoconsumo', palanca: 'Renovables', horizonte: 'Medio plazo' },
+      { medida: 'Eficiencia energética (LED, HVAC, BMS)', palanca: 'Eficiencia', horizonte: 'Corto plazo' },
+    ]
+  if (cat.includes('gas') || cat.includes('caldera') || cat.includes('termic'))
+    return [
+      { medida: 'Eficiencia térmica (aislamiento + recuperación de calor)', palanca: 'Eficiencia', horizonte: 'Corto plazo' },
+      { medida: 'Electrificación de calderas (bomba de calor)', palanca: 'Electrificación', horizonte: 'Medio plazo' },
+      { medida: 'Sustitución por biogás o hidrógeno verde', palanca: 'Sustitución', horizonte: 'Largo plazo' },
+    ]
+  if (cat.includes('transport') || cat.includes('vehicul') || cat.includes('flota') || cat.includes('diesel') || cat.includes('gasolin'))
+    return [
+      { medida: 'Electrificación de flota (BEV)', palanca: 'Electrificación', horizonte: 'Medio plazo' },
+      { medida: 'Optimización de rutas y eco-driving', palanca: 'Eficiencia', horizonte: 'Corto plazo' },
+      { medida: 'Combustibles alternativos (HVO)', palanca: 'Sustitución', horizonte: 'Corto plazo' },
+    ]
+  if (cat.includes('refrig') || cat.includes('fugitiv'))
+    return [
+      { medida: 'Sustitución de refrigerantes de alto GWP', palanca: 'Sustitución', horizonte: 'Medio plazo' },
+      { medida: 'Mejora de estanqueidad y mantenimiento', palanca: 'Eficiencia', horizonte: 'Corto plazo' },
+    ]
+  return [{ medida: 'Auditoría energética específica', palanca: 'Eficiencia', horizonte: 'Corto plazo' }]
+}
+
+function estimateReduction(categoria, tCO2e) {
+  const cat = (categoria || '').toLowerCase()
+  if (cat.includes('electric') || cat.includes('grid')) return Math.round(tCO2e * 0.9 * 10) / 10
+  if (cat.includes('gas') || cat.includes('caldera')) return Math.round(tCO2e * 0.6 * 10) / 10
+  if (cat.includes('transport') || cat.includes('vehicul')) return Math.round(tCO2e * 0.5 * 10) / 10
+  return Math.round(tCO2e * 0.3 * 10) / 10
+}
+
+// ── Phase 3: Pathway — build reduction plan ──────────────────────────
+export function buildPathway(diagnostic) {
+  const measures = []
+  let counter = 0
+  diagnostic.priorities.forEach(src => {
+    (src.alternatives || []).forEach(alt => {
+      counter++
+      const vidaUtil = alt.horizonte === 'Corto plazo' ? 10 : alt.horizonte === 'Medio plazo' ? 12 : 15
+      const reductionShare = alt.horizonte === 'Corto plazo' ? 0.15 : alt.horizonte === 'Medio plazo' ? 0.30 : 0.20
+      measures.push({
+        id: `M-${String(counter).padStart(3, '0')}`,
+        nombre: alt.medida,
+        palanca: alt.palanca,
+        horizonte: alt.horizonte,
+        source_nombre: src.nombre,
+        scope: src.scope,
+        tCO2e_anuales: Math.round(src.tCO2e * reductionShare * 10) / 10,
+        vida_util_anios: vidaUtil,
+        capex_eur: 0,
+        ahorro_anual_eur: 0,
+      })
+    })
+  })
+  return measures
+}
+
+// ── Phase 4: Financial / MACC ────────────────────────────────────────
+export function calculateMACC(measures) {
+  const entries = measures
+    .filter(m => m.capex_eur > 0 || m.ahorro_anual_eur > 0)
+    .map(m => {
+      const acumuladas = m.tCO2e_anuales * m.vida_util_anios
+      const costeNeto = m.capex_eur - (m.ahorro_anual_eur * m.vida_util_anios)
+      const macc = acumuladas > 0 ? costeNeto / acumuladas : Infinity
+      const payback = m.ahorro_anual_eur > 0 ? m.capex_eur / m.ahorro_anual_eur : Infinity
+      return {
+        ...m,
+        tCO2e_acumuladas: Math.round(acumuladas * 10) / 10,
+        coste_neto_eur: Math.round(costeNeto * 100) / 100,
+        macc_eur_tCO2e: Math.round(macc * 100) / 100,
+        payback_anios: Math.round(payback * 10) / 10,
+      }
+    })
+    .sort((a, b) => a.macc_eur_tCO2e - b.macc_eur_tCO2e)
+
+  // Build curve coordinates
+  let cumulative = 0
+  const curve = entries.map(e => {
+    const x_start = cumulative
+    cumulative += e.tCO2e_acumuladas
+    return { ...e, x_start: Math.round(x_start), x_end: Math.round(cumulative) }
+  })
+
+  const totalReduction = entries.reduce((s, e) => s + e.tCO2e_acumuladas, 0)
+  const totalInvestment = entries.reduce((s, e) => s + e.capex_eur, 0)
+
+  return {
+    ranking: curve,
+    reduccion_total_tCO2e: Math.round(totalReduction * 10) / 10,
+    inversion_total_eur: Math.round(totalInvestment),
+    coste_medio: totalReduction > 0 ? Math.round((totalInvestment / totalReduction) * 100) / 100 : 0,
+    medidas_ahorro: entries.filter(e => e.macc_eur_tCO2e < 0).length,
+  }
+}
+
+// ── CSV Parser ───────────────────────────────────────────────────────
+export function parseCSV(text) {
+  const lines = text.trim().split('\n')
+  if (lines.length < 2) return []
+  const headers = lines[0].split(/[,;\t]/).map(h => h.trim().toLowerCase().replace(/['"]/g, ''))
+  return lines.slice(1).filter(l => l.trim()).map(line => {
+    const values = line.split(/[,;\t]/).map(v => v.trim().replace(/['"]/g, ''))
+    const row = {}
+    headers.forEach((h, i) => {
+      const val = values[i] || ''
+      row[h] = isNaN(val) || val === '' ? val : parseFloat(val)
+    })
+    return row
+  })
+}
+
+// ── CSV/Excel Export ─────────────────────────────────────────────────
+export function toCSV(headers, rows) {
+  const headerLine = headers.join(';')
+  const dataLines = rows.map(row => headers.map(h => row[h] ?? '').join(';'))
+  return '\uFEFF' + [headerLine, ...dataLines].join('\n')
+}
+
+export function downloadFile(content, filename, mime = 'text/csv;charset=utf-8') {
+  const blob = new Blob([content], { type: mime })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}
+
+// ── Default cost catalog for auto-populating economics ───────────────
+export const COST_CATALOG = {
+  'PPA': { capex: 15000, ahorro: 80000 },
+  'fotovoltaica': { capex: 450000, ahorro: 55000 },
+  'eficiencia energética': { capex: 120000, ahorro: 45000 },
+  'eficiencia térmica': { capex: 95000, ahorro: 35000 },
+  'bomba de calor': { capex: 600000, ahorro: 40000 },
+  'biogás': { capex: 350000, ahorro: 15000 },
+  'hidrógeno': { capex: 350000, ahorro: 15000 },
+  'BEV': { capex: 900000, ahorro: 60000 },
+  'eco-driving': { capex: 25000, ahorro: 15000 },
+  'HVO': { capex: 10000, ahorro: 5000 },
+  'refrigerantes': { capex: 80000, ahorro: 10000 },
+  'estanqueidad': { capex: 30000, ahorro: 8000 },
+  'Auditoría': { capex: 40000, ahorro: 12000 },
+}
+
+export function autoAssignCosts(measures) {
+  return measures.map(m => {
+    const name = m.nombre.toLowerCase()
+    for (const [key, costs] of Object.entries(COST_CATALOG)) {
+      if (name.includes(key.toLowerCase())) {
+        return { ...m, capex_eur: costs.capex, ahorro_anual_eur: costs.ahorro }
+      }
+    }
+    return { ...m, capex_eur: 50000, ahorro_anual_eur: 10000 }
+  })
+}


### PR DESCRIPTION
Three-step interactive tool accessible via "Decarb Tool" button in navbar:

Panel 1 — Input (FileUploadPanel):
  - CSV file uploader with drag & drop
  - Downloadable CSV template
  - Demo data loader for quick testing
  - Editable source table (scope, category, quantity, emission factor)
  - Organization metadata form

Panel 2 — Calculation (CalculationTable):
  - GHG inventory results with scope distribution bars
  - Diagnostic: top 3-5 priority sources covering ~80% emissions
  - SBTi 1.5°C trajectory visualization
  - Editable reduction measures with auto-cost assignment
  - CSV export for inventory and measures

Panel 3 — Report (ReportOutput):
  - Full decarbonization plan with executive summary
  - Visual MACC curve (positive/negative cost bars)
  - Ranked measures table with MACC, payback, net cost
  - Implementation roadmap by time horizon
  - PDF download via print-to-PDF

Client-side JS engine (decarbEngine.js) mirrors the Python backend:
  Emisiones = Dato_Actividad × Factor_Emision × GWP × Factor_Consolidacion
  Coste_Neto = CAPEX - (Ahorro × Vida_Util)
  MACC = Coste_Neto / tCO2e_acumuladas

https://claude.ai/code/session_01SwkUC7PRFDVm5WFTBNeEAN